### PR TITLE
Develop

### DIFF
--- a/Website/Website/Pages/Portfolio.razor
+++ b/Website/Website/Pages/Portfolio.razor
@@ -387,10 +387,10 @@
         if (firstRender)
         {
             jsObjRef = await jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Pages/Portfolio.razor.js");
-
             await jsObjRef.InvokeVoidAsync("OnAfterRenderAsync");
-        }
 
+            await ParallaxWrapperEl.SetBgZTransform(-900);
+        }
 
 
 

--- a/Website/Website/Pages/Portfolio.razor
+++ b/Website/Website/Pages/Portfolio.razor
@@ -4,7 +4,6 @@
 @inject IJSRuntime jsRuntime;
 
 <ParallaxWrapper @ref=ParallaxWrapperEl>
-        <div id="BG" class="HorizontalDebugBG"/>   @* parallax background the size of the page *@
 
         <div style="opacity:.25;">
             <div class="container" style="background-color:aqua;">

--- a/Website/Website/Pages/Portfolio.razor
+++ b/Website/Website/Pages/Portfolio.razor
@@ -6,6 +6,10 @@
 <ParallaxWrapper @ref=ParallaxWrapperEl>
         <div id="BG" class="HorizontalDebugBG"/>   @* parallax background the size of the page *@
 
+        <div class="ParallaxOriginCenter">
+            <div id="Dots" class="CoolDottedBG"/>
+        </div>
+
         <div style="opacity:.25;">
             <div class="container" style="background-color:aqua;">
                 <div class="row align-items-center">

--- a/Website/Website/Pages/Portfolio.razor
+++ b/Website/Website/Pages/Portfolio.razor
@@ -5,7 +5,7 @@
 
 <ParallaxWrapper @ref=ParallaxWrapperEl>
     <BackgroundContent>
-        <div id="BG" class="HorizontalDebugBG Override"/>
+        <div id="BG" class="HorizontalDebugBG"/>
     </BackgroundContent>
 
     <PageContent>

--- a/Website/Website/Pages/Portfolio.razor
+++ b/Website/Website/Pages/Portfolio.razor
@@ -6,10 +6,6 @@
 <ParallaxWrapper @ref=ParallaxWrapperEl>
         <div id="BG" class="HorizontalDebugBG"/>   @* parallax background the size of the page *@
 
-        <div class="ParallaxOriginCenter">
-            <div id="Dots" class="CoolDottedBG"/>
-        </div>
-
         <div style="opacity:.25;">
             <div class="container" style="background-color:aqua;">
                 <div class="row align-items-center">

--- a/Website/Website/Pages/Portfolio.razor
+++ b/Website/Website/Pages/Portfolio.razor
@@ -388,11 +388,6 @@
         {
             jsObjRef = await jsRuntime.InvokeAsync<IJSObjectReference>("import", "./Pages/Portfolio.razor.js");
             await jsObjRef.InvokeVoidAsync("OnAfterRenderAsync");
-
-            await ParallaxWrapperEl.SetBgZTransform(-900);
         }
-
-
-
     }
 }

--- a/Website/Website/Pages/Portfolio.razor
+++ b/Website/Website/Pages/Portfolio.razor
@@ -4,7 +4,11 @@
 @inject IJSRuntime jsRuntime;
 
 <ParallaxWrapper @ref=ParallaxWrapperEl>
+    <BackgroundContent>
+        <div id="BG" class="HorizontalDebugBG Override"/>
+    </BackgroundContent>
 
+    <PageContent>
         <div style="opacity:.25;">
             <div class="container" style="background-color:aqua;">
                 <div class="row align-items-center">
@@ -368,6 +372,7 @@
                 </div>
             </div> 
         </div>
+    </PageContent>
 </ParallaxWrapper>
 
         

--- a/Website/Website/Pages/Portfolio.razor
+++ b/Website/Website/Pages/Portfolio.razor
@@ -18,9 +18,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
-                            <iframe src="https://www.youtube.com/embed/50GLtzGa2F0" title="YouTube video player" frameborder="1" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="text-center embed-responsive-item"></iframe>
-                        </div>
+
                     </div>
                 </div>
             </div>
@@ -35,9 +33,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -52,9 +48,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -69,9 +63,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -86,9 +78,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -103,9 +93,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -120,9 +108,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
-                            <iframe src="https://www.youtube.com/embed/50GLtzGa2F0" title="YouTube video player" frameborder="1" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="text-center embed-responsive-item"></iframe>
-                        </div>
+                        
                     </div>
                 </div>
             </div>
@@ -137,9 +123,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -154,9 +138,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -171,9 +153,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -188,9 +168,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -205,9 +183,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -223,9 +199,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
-                            <iframe src="https://www.youtube.com/embed/50GLtzGa2F0" title="YouTube video player" frameborder="1" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="text-center embed-responsive-item"></iframe>
-                        </div>
+                        
                     </div>
                 </div>
             </div>
@@ -240,9 +214,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -257,9 +229,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -274,9 +244,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -291,9 +259,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -308,9 +274,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -325,9 +289,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
-                            <iframe src="https://www.youtube.com/embed/50GLtzGa2F0" title="YouTube video player" frameborder="1" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="text-center embed-responsive-item"></iframe>
-                        </div>
+                        
                     </div>
                 </div>
             </div>
@@ -342,9 +304,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -359,9 +319,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -376,9 +334,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -393,9 +349,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div>
@@ -410,9 +364,7 @@
                     
                     </div>
                     <div class="col-md-4 bg-dark">
-                        <div class="embed-responsive embed-responsive-16by9">
                         
-                        </div>
                     </div>
                 </div>
             </div> 

--- a/Website/Website/Pages/Portfolio.razor.css
+++ b/Website/Website/Pages/Portfolio.razor.css
@@ -1,9 +1,1 @@
-﻿#BG
-{
-    position: absolute;
-    z-index: -1;
-    width: 100vw;
-    height: 100%;
-
-    --bgZTransform: -9000px; /* custom CSS property ParallaxWrapper component looks for when performing the BG element's transform */
-}
+﻿

--- a/Website/Website/Pages/Portfolio.razor.css
+++ b/Website/Website/Pages/Portfolio.razor.css
@@ -7,3 +7,21 @@
 
     --bgZTransform: -9000px; /* custom CSS property ParallaxWrapper component looks for when performing the BG element's transform */
 }
+
+.ParallaxOriginCenter 
+{
+    -webkit-perspective: 300px;
+    perspective: 300px;
+    -webkit-perspective-origin: center top;
+    perspective-origin: center top;
+    -webkit-transform-style: preserve-3d;
+    transform-style: preserve-3d;
+}
+#Dots
+{
+    width: 100vw;
+    height: 100vh;
+    position: absolute;
+
+    transform: translateZ(-300px) scale(3);
+}

--- a/Website/Website/Pages/Portfolio.razor.css
+++ b/Website/Website/Pages/Portfolio.razor.css
@@ -1,1 +1,9 @@
-﻿
+﻿#BG
+{
+    position: absolute;
+    z-index: -1;
+    width: 100vw;
+    height: 100%;
+
+    --bgZTransform: -9000px; /* custom CSS property ParallaxWrapper component looks for when performing the BG element's transform */
+}

--- a/Website/Website/Pages/Portfolio.razor.css
+++ b/Website/Website/Pages/Portfolio.razor.css
@@ -1,1 +1,16 @@
-﻿
+﻿#BG
+{
+    width: 100vw; /* vw because for some reason using % doesn't fill up whole page width space */
+    height: 100%; 
+}
+
+@media screen and (min-width: 40em) /* only non-mobile devices */
+{
+    @supports ((--foo: bar) and ((perspective: 300px) or (-moz-perspective: 300px) or (-webkit-perspective: 300px)) and (not (-webkit-overflow-scrolling: touch))) /* only if supports CSS custom properties and perspective property and then some thing at the end that apparently helps */ 
+    {
+        #BG 
+        {
+            --bgZTransform: -9000px;
+        }
+    }
+}

--- a/Website/Website/Pages/Portfolio.razor.css
+++ b/Website/Website/Pages/Portfolio.razor.css
@@ -7,21 +7,3 @@
 
     --bgZTransform: -9000px; /* custom CSS property ParallaxWrapper component looks for when performing the BG element's transform */
 }
-
-.ParallaxOriginCenter 
-{
-    -webkit-perspective: 300px;
-    perspective: 300px;
-    -webkit-perspective-origin: center top;
-    perspective-origin: center top;
-    -webkit-transform-style: preserve-3d;
-    transform-style: preserve-3d;
-}
-#Dots
-{
-    width: 100vw;
-    height: 100vh;
-    position: absolute;
-
-    transform: translateZ(-300px) scale(3);
-}

--- a/Website/Website/Properties/ServiceDependencies/BrianHinkle - Web Deploy/profile.arm.json
+++ b/Website/Website/Properties/ServiceDependencies/BrianHinkle - Web Deploy/profile.arm.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_dependencyType": "compute.appService.windows"
+  },
+  "parameters": {
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "PersonalWebsite",
+      "metadata": {
+        "description": "Name of the resource group for the resource. It is recommended to put resources under same resource group for better tracking."
+      }
+    },
+    "resourceGroupLocation": {
+      "type": "string",
+      "defaultValue": "eastus2",
+      "metadata": {
+        "description": "Location of the resource group. Resource groups could have different location than resources, however by default we use API versions from latest hybrid profile which support all locations for resource types we support."
+      }
+    },
+    "resourceName": {
+      "type": "string",
+      "defaultValue": "BrianHinkle",
+      "metadata": {
+        "description": "Name of the main resource to be created by this template."
+      }
+    },
+    "resourceLocation": {
+      "type": "string",
+      "defaultValue": "[parameters('resourceGroupLocation')]",
+      "metadata": {
+        "description": "Location of the resource. By default use resource group's location, unless the resource provider is not supported there."
+      }
+    }
+  },
+  "variables": {
+    "appServicePlan_name": "[concat('Plan', uniqueString(concat(parameters('resourceName'), subscription().subscriptionId)))]",
+    "appServicePlan_ResourceId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('resourceGroupName'), '/providers/Microsoft.Web/serverFarms/', variables('appServicePlan_name'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[parameters('resourceGroupLocation')]",
+      "apiVersion": "2019-10-01"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(parameters('resourceGroupName'), 'Deployment', uniqueString(concat(parameters('resourceName'), subscription().subscriptionId)))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "apiVersion": "2019-10-01",
+      "dependsOn": [
+        "[parameters('resourceGroupName')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "location": "[parameters('resourceLocation')]",
+              "name": "[parameters('resourceName')]",
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2015-08-01",
+              "tags": {
+                "[concat('hidden-related:', variables('appServicePlan_ResourceId'))]": "empty"
+              },
+              "dependsOn": [
+                "[variables('appServicePlan_ResourceId')]"
+              ],
+              "kind": "app",
+              "properties": {
+                "name": "[parameters('resourceName')]",
+                "kind": "app",
+                "httpsOnly": true,
+                "reserved": false,
+                "serverFarmId": "[variables('appServicePlan_ResourceId')]",
+                "siteConfig": {
+                  "metadata": [
+                    {
+                      "name": "CURRENT_STACK",
+                      "value": "dotnetcore"
+                    }
+                  ]
+                }
+              },
+              "identity": {
+                "type": "SystemAssigned"
+              }
+            },
+            {
+              "location": "[parameters('resourceLocation')]",
+              "name": "[variables('appServicePlan_name')]",
+              "type": "Microsoft.Web/serverFarms",
+              "apiVersion": "2015-08-01",
+              "sku": {
+                "name": "S1",
+                "tier": "Standard",
+                "family": "S",
+                "size": "S1"
+              },
+              "properties": {
+                "name": "[variables('appServicePlan_name')]"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor
@@ -4,13 +4,13 @@
 
     <div id="BGParallaxWrapper">
         <div id="BGPageContent">
-            <div id="BG" class="HorizontalDebugBG"/>
+            @BackgroundContent
         </div>
     </div>
 
     <div id="ParallaxWrapper">  @* Wrapper the size of the viewport *@
         <div id="PageContent" class="HorizontalDebugBGFaded">  @* 2nd wrapper to allow for dynamic height *@
-            @ChildContent
+            @PageContent
         </div>
     </div>
 
@@ -22,7 +22,9 @@
 @code 
 {
     [Parameter]
-        public RenderFragment ChildContent { get; set; }
+        public RenderFragment BackgroundContent { get; set; }
+    [Parameter]
+        public RenderFragment PageContent { get; set; }
 
     private IJSObjectReference jsObjRef;    // js interactor
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor
@@ -1,15 +1,19 @@
 ﻿@inject IJSRuntime jsRuntime;
 
-<div id="BGParallaxWrapper">  @* Wrapper the size of the viewport *@
-    <div id="BGPageContent">
-        <div id="BG" class="HorizontalDebugBG"/>   @* parallax background the size of the page *@
-    </div>
-</div>
+<div id="SharedVariablesWrapper">
 
-<div id="ParallaxWrapper">  @* Wrapper the size of the viewport *@
-    <div id="PageContent" class="HorizontalDebugBGFaded">  @* 2nd wrapper to allow for dynamic height *@
-        @ChildContent
+    <div id="BGParallaxWrapper">  @* Wrapper the size of the viewport *@
+        <div id="BGPageContent">
+            <div id="BG" class="HorizontalDebugBG"/>   @* parallax background the size of the page *@
+        </div>
     </div>
+
+    <div id="ParallaxWrapper">  @* Wrapper the size of the viewport *@
+        <div id="PageContent" class="HorizontalDebugBGFaded">  @* 2nd wrapper to allow for dynamic height *@
+            @ChildContent
+        </div>
+    </div>
+
 </div>
 
     

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor
@@ -24,13 +24,4 @@
             await jsObjRef.InvokeVoidAsync("OnAfterRenderAsync");
         }
     }
-    
-    // BEGIN configurable variables
-    public async Task SetBgZTransform(float inBGZTransform)
-    {
-        if (jsObjRef != null)
-        {
-            await jsObjRef.InvokeVoidAsync("SetBgZTransform", inBGZTransform);
-        }
-    }
 }

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor
@@ -4,7 +4,7 @@
 
     <div id="BGParallaxWrapper">
         <div id="BGPageContent">
-            @BackgroundContent
+            @BackgroundContent @* Requiers id of "BG" *@
         </div>
     </div>
 

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor
@@ -1,5 +1,11 @@
 ﻿@inject IJSRuntime jsRuntime;
 
+<div id="BGParallaxWrapper">  @* Wrapper the size of the viewport *@
+    <div id="BGPageContent">
+        <div id="BG" class="HorizontalDebugBG"/>   @* parallax background the size of the page *@
+    </div>
+</div>
+
 <div id="ParallaxWrapper">  @* Wrapper the size of the viewport *@
     <div id="PageContent" class="HorizontalDebugBGFaded">  @* 2nd wrapper to allow for dynamic height *@
         @ChildContent

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor
@@ -2,9 +2,9 @@
 
 <div id="SharedVariablesWrapper">
 
-    <div id="BGParallaxWrapper">  @* Wrapper the size of the viewport *@
+    <div id="BGParallaxWrapper">
         <div id="BGPageContent">
-            <div id="BG" class="HorizontalDebugBG"/>   @* parallax background the size of the page *@
+            <div id="BG" class="HorizontalDebugBG"/>
         </div>
     </div>
 

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -19,7 +19,7 @@
 }
 #BG
 {
-    width: 100%;
+    width: 100vw;
     height: 100%;
 }
 #ParallaxWrapper 

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -20,15 +20,6 @@
 }
 
 
-::deep > #BG /* ::deep means for ChildContent */ 
-{
-    position: absolute;
-    z-index: -1;
-    width: 100vw;
-    height: 100%;
-}
-
-
 /* Parallax enhancement for larger screens... */
 /* Conditionally apply */
 @media screen and (min-width: 40em) /* only non-mobile devices */
@@ -56,10 +47,10 @@
         }
 
 
-        ::deep > #BG /* ::deep means for ChildContent */
+        ::deep > #BG /* ::deep means for ChildContent. NOTE: When using ::deep, any styles will override the child component's styles for that selector (I'm guessing because it applies parent's ::deep styles after) */
         {
         /* BEGIN variables */
-            --bgZTransform: 0px;    /* set by JS */
+         /* --bgZTransform   is required to be set by the child component */
             --widthScale: 1;        /* set by JS */
             --heightScale: 1;       /* set by JS */
         /* END variables */

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -1,6 +1,8 @@
-﻿#SharedVariablesWrapper
+﻿#SharedVariablesWrapper 
 {
-
+/* BEGIN variables */
+    --ParallaxSupported: false; /* read from in JS */
+/* BEGIN variables */
 }
 
 

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -22,11 +22,15 @@
 #BGPageContent
 {
     position: relative;
+
+/* fallback sizing in scenerio where parallax isn't supported */
+    width: 100vw;
+    height: 100vh;
 }
 #BG
 {
-    width: 100vw;
-    height: 100%;
+    width: 100vw; /* vw because for some reason using % doesn't fill up whole page width space */
+    height: 100%; 
 }
 #ParallaxWrapper 
 {

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -33,7 +33,7 @@
 /* Conditionally apply */
 @media screen and (min-width: 40em) /* only non-mobile devices */
 {
-    @supports ((perspective: 300px) and (not (-webkit-overflow-scrolling: touch))) 
+    @supports (((perspective: 300px) or (-moz-perspective: 300px) or (-webkit-perspective: 300px)) and (not (-webkit-overflow-scrolling: touch)))
     {
         #ParallaxWrapper
         {

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -27,11 +27,6 @@
     width: 100vw;
     height: 100vh;
 }
-#BG
-{
-    width: 100vw; /* vw because for some reason using % doesn't fill up whole page width space */
-    height: 100%; 
-}
 #ParallaxWrapper 
 {
     z-index: 0;
@@ -101,10 +96,10 @@
             width: var(--PageWidth);
             height: var(--PageHeight);
         }
-        #BG
+        ::deep #BG
         {
             /* BEGIN variables */
-            --bgZTransform: -90px; /* custom CSS property ParallaxWrapper component looks for when performing the BG element's transform */
+            /*--bgZTransform: -90px;*/ /* custom CSS property ParallaxWrapper component looks for when performing the BG element's transform */
             --widthScale: 1;        /* set by JS */
             --heightScale: 1;       /* set by JS */
             /* END variables */

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -1,4 +1,10 @@
-﻿#BGParallaxWrapper
+﻿#SharedVariablesWrapper
+{
+
+}
+
+
+#BGParallaxWrapper
 {
     z-index: -1;
     position: absolute; /* make elements in this group relative to the whole pange, because we are going to have to use absolutly positioned elements */
@@ -50,18 +56,22 @@
 {
     @supports ((--foo: bar) and ((perspective: 300px) or (-moz-perspective: 300px) or (-webkit-perspective: 300px)) and (not (-webkit-overflow-scrolling: touch))) /* only if supports CSS custom properties and perspective property and then some thing at the end that apparently helps */
     {
-        #ParallaxWrapper
+        #SharedVariablesWrapper
         {
         /* BEGIN variables */
             --ParallaxSupported: true; /* read from in JS */
-            --perspectiveValue: 300px; /* read from in JS */
+            --PerspectiveValue: 300px; /* read from in JS */
         /* END variables */
+        }
 
+
+        #ParallaxWrapper
+        {
             /* This is our scrolling div so this is where we must define the perspective */
             -webkit-perspective-origin: center bottom;
             perspective-origin: center bottom; /* vanishing point at 50% 100%. We do this to prevent Y overflow scrolling since overflow:hidden doesn't work for 3D */
-            -webkit-perspective: var(--perspectiveValue);
-            perspective: var(--perspectiveValue); /* avoid a -1 perspective value since it has shown unpredictable results accross browsers when zooming out. I've seen 300px used in a few places so I'll go with that. */
+            -webkit-perspective: var(--PerspectiveValue);
+            perspective: var(--PerspectiveValue); /* avoid a -1 perspective value since it has shown unpredictable results accross browsers when zooming out. I've seen 300px used in a few places so I'll go with that. */
         }
         #PageContent /* pourpose for this 2nd wrapper is so that content of the page can be parented to a dynamically sized div (instead of ParallaxWrapper's 100vh) */
         {
@@ -74,8 +84,8 @@
             /* This is our scrolling div so this is where we must define the perspective */
             -webkit-perspective-origin: center bottom;
             perspective-origin: center bottom; /* vanishing point at 50% 100%. We do this to prevent Y overflow scrolling since overflow:hidden doesn't work for 3D */
-            -webkit-perspective: 300px;
-            perspective: 300px; /* avoid a -1 perspective value since it has shown unpredictable results accross browsers when zooming out. I've seen 300px used in a few places so I'll go with that. */
+            -webkit-perspective: var(--PerspectiveValue);
+            perspective: var(--PerspectiveValue); /* avoid a -1 perspective value since it has shown unpredictable results accross browsers when zooming out. I've seen 300px used in a few places so I'll go with that. */
         }
         #BGPageContent
         {

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -37,7 +37,7 @@
 
 
 
-::deep #BG /* ::deep means to do it for ChildContent */
+::deep > #BG /* ::deep means for ChildContent */
 {
     position: absolute;
     z-index: -1;

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -33,11 +33,12 @@
 /* Conditionally apply */
 @media screen and (min-width: 40em) /* only non-mobile devices */
 {
-    @supports (((perspective: 300px) or (-moz-perspective: 300px) or (-webkit-perspective: 300px)) and (not (-webkit-overflow-scrolling: touch)))
+    @supports ((--foo: bar) and ((perspective: 300px) or (-moz-perspective: 300px) or (-webkit-perspective: 300px)) and (not (-webkit-overflow-scrolling: touch))) /* only if supports CSS custom properties and perspective property and then some thing at the end that apparently helps */
     {
         #ParallaxWrapper
         {
         /* BEGIN variables */
+            --ParallaxSupported: true; /* read from in JS */
             --perspectiveOrigin: center bottom;
             --perspectiveValue: 0px; /* set by JS */
         /* END variables */

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -39,8 +39,8 @@
         {
         /* BEGIN variables */
             --ParallaxSupported: true; /* read from in JS */
+            --perspectiveValue: 300px; /* read from in JS */
             --perspectiveOrigin: center bottom;
-            --perspectiveValue: 0px; /* set by JS */
         /* END variables */
 
             /* This is our scrolling div so this is where we must define the perspective */

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -23,7 +23,7 @@
 {
     position: relative;
 
-/* fallback sizing in scenerio where parallax isn't supported */
+/* fallback sizing in scenerio where parallax isn't supported. (In the future may want to still make this the same size as the page's content since that is still possible) */
     width: 100vw;
     height: 100vh;
 }

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -1,5 +1,30 @@
-﻿#ParallaxWrapper 
+﻿#BGParallaxWrapper
 {
+    z-index: -1;
+    position: absolute; /* make elements in this group relative to the whole pange, because we are going to have to use absolutly positioned elements */
+    width: 100vw;
+    height: 100vh;
+    padding: 0px;
+	margin: 0px;
+
+    -webkit-box-sizing:border-box;
+    box-sizing:border-box;
+    
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+#BGPageContent
+{
+    position: relative;
+}
+#BG
+{
+    width: 100%;
+    height: 100%;
+}
+#ParallaxWrapper 
+{
+    z-index: 0;
     position: relative; /* make elements in this group relative to the whole pange, because we are going to have to use absolutly positioned elements */
     width: 100vw;
     height: 100vh;
@@ -11,7 +36,6 @@
     
     overflow-x: hidden;
     overflow-y: auto;
-
     
 }
 #PageContent /* pourpose for this 2nd wrapper is so that content of the page can be parented to a dynamically sized div */
@@ -31,12 +55,11 @@
         /* BEGIN variables */
             --ParallaxSupported: true; /* read from in JS */
             --perspectiveValue: 300px; /* read from in JS */
-            --perspectiveOrigin: center bottom;
         /* END variables */
 
             /* This is our scrolling div so this is where we must define the perspective */
-            -webkit-perspective-origin: var(--perspectiveOrigin);
-            perspective-origin: var(--perspectiveOrigin); /* vanishing point at 50% 100%. We do this to prevent Y overflow scrolling since overflow:hidden doesn't work for 3D */
+            -webkit-perspective-origin: center bottom;
+            perspective-origin: center bottom; /* vanishing point at 50% 100%. We do this to prevent Y overflow scrolling since overflow:hidden doesn't work for 3D */
             -webkit-perspective: var(--perspectiveValue);
             perspective: var(--perspectiveValue); /* avoid a -1 perspective value since it has shown unpredictable results accross browsers when zooming out. I've seen 300px used in a few places so I'll go with that. */
         }
@@ -45,20 +68,39 @@
             -webkit-transform-style: preserve-3d;
             transform-style: preserve-3d;
         }
-
-
-        ::deep > #BG /* ::deep means for ChildContent. NOTE: When using ::deep, any styles will override the child component's styles for that selector (I'm guessing because it applies parent's ::deep styles after) */
+        
+        #BGParallaxWrapper
         {
-        /* BEGIN variables */
-         /* --bgZTransform   is required to be set by the child component */
+            /* This is our scrolling div so this is where we must define the perspective */
+            -webkit-perspective-origin: center bottom;
+            perspective-origin: center bottom; /* vanishing point at 50% 100%. We do this to prevent Y overflow scrolling since overflow:hidden doesn't work for 3D */
+            -webkit-perspective: 300px;
+            perspective: 300px; /* avoid a -1 perspective value since it has shown unpredictable results accross browsers when zooming out. I've seen 300px used in a few places so I'll go with that. */
+        }
+        #BGPageContent
+        {
+            -webkit-transform-style: preserve-3d;
+            transform-style: preserve-3d;
+
+            --PageWidth: 0px;    /* set by JS */
+            --PageHeight: 0px;   /* set by JS */
+            width: var(--PageWidth);
+            height: var(--PageHeight);
+        }
+        #BG
+        {
+            /* BEGIN variables */
+            --bgZTransform: -90px; /* custom CSS property ParallaxWrapper component looks for when performing the BG element's transform */
             --widthScale: 1;        /* set by JS */
             --heightScale: 1;       /* set by JS */
-        /* END variables */
-            -webkit-transform-origin: var(--perspectiveOrigin);
-            transform-origin: var(--perspectiveOrigin);
+            /* END variables */
+            -webkit-transform-origin: center bottom;
+            transform-origin: center bottom;
             -webkit-transform: translateZ(var(--bgZTransform)) scale(var(--widthScale), var(--heightScale));
             transform: translateZ(var(--bgZTransform)) scale(var(--widthScale), var(--heightScale));
         }
+
+
     }
 }
 

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.css
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.css
@@ -1,15 +1,7 @@
 ﻿#ParallaxWrapper 
 {
-/* BEGIN Variables */
-    --perspectiveOrigin: center bottom;
-/* END Variables */
-/* BEGIN JS set variables */
-    --perspectiveValue: 0px;
-/* END JS set variables */
-
     position: relative; /* make elements in this group relative to the whole pange, because we are going to have to use absolutly positioned elements */
     width: 100vw;
-    height: 500px; /* fallback for older browsers */
     height: 100vh;
     padding: 0px;
 	margin: 0px;
@@ -20,41 +12,64 @@
     overflow-x: hidden;
     overflow-y: auto;
 
-    /* BEGIN Perspective */ /* We define the perspective here since this is our scrolling div */
-    -webkit-perspective-origin: var(--perspectiveOrigin);
-    perspective-origin: var(--perspectiveOrigin); /* vanishing point at 50% 100% */
-    -webkit-perspective: var(--perspectiveValue);
-    perspective: var(--perspectiveValue); /* avoid a -1 perspective value since it has shown unpredictable results accross browsers when zooming out. I've seen 300px used in a few places so I'll go with that. */
-    /* END Perspective */
+    
 }
 #PageContent /* pourpose for this 2nd wrapper is so that content of the page can be parented to a dynamically sized div */
 {
-    /* BEGIN 3D rendering context */ /* This is where our 3D content starts */
-    -webkit-transform-style: preserve-3d;
-    transform-style: preserve-3d;
-    /* END 3D rendering context */
+    position: relative; /* we use relative position here so that #BG will look to this when deciding its height instead of the next available relative positioned element (#ParallaxWrapper) */
 }
 
 
-
-::deep > #BG /* ::deep means for ChildContent */
+::deep > #BG /* ::deep means for ChildContent */ 
 {
     position: absolute;
     z-index: -1;
     width: 100vw;
     height: 100%;
-
-
-
-    /* Time for parallax.... */
-/* BEGIN JS set variables */
-    --bgZTransform: 0px;
-    --widthScale: 1;
-    --heightScale: 1;
-/* END JS set variables */
-    -webkit-transform-origin: var(--perspectiveOrigin); /* results in 50% 100% to its parent */
-    transform-origin: var(--perspectiveOrigin);
-    -webkit-transform: translateZ(var(--bgZTransform)) scale(var(--widthScale), var(--heightScale));
-    transform: translateZ(var(--bgZTransform)) scale(var(--widthScale), var(--heightScale));
 }
+
+
+/* Parallax enhancement for larger screens... */
+/* Conditionally apply */
+@media screen and (min-width: 40em) /* only non-mobile devices */
+{
+    @supports ((perspective: 300px) and (not (-webkit-overflow-scrolling: touch))) 
+    {
+        #ParallaxWrapper
+        {
+        /* BEGIN variables */
+            --perspectiveOrigin: center bottom;
+            --perspectiveValue: 0px; /* set by JS */
+        /* END variables */
+
+            /* This is our scrolling div so this is where we must define the perspective */
+            -webkit-perspective-origin: var(--perspectiveOrigin);
+            perspective-origin: var(--perspectiveOrigin); /* vanishing point at 50% 100%. We do this to prevent Y overflow scrolling since overflow:hidden doesn't work for 3D */
+            -webkit-perspective: var(--perspectiveValue);
+            perspective: var(--perspectiveValue); /* avoid a -1 perspective value since it has shown unpredictable results accross browsers when zooming out. I've seen 300px used in a few places so I'll go with that. */
+        }
+        #PageContent /* pourpose for this 2nd wrapper is so that content of the page can be parented to a dynamically sized div (instead of ParallaxWrapper's 100vh) */
+        {
+            -webkit-transform-style: preserve-3d;
+            transform-style: preserve-3d;
+        }
+
+
+        ::deep > #BG /* ::deep means for ChildContent */
+        {
+        /* BEGIN variables */
+            --bgZTransform: 0px;    /* set by JS */
+            --widthScale: 1;        /* set by JS */
+            --heightScale: 1;       /* set by JS */
+        /* END variables */
+            -webkit-transform-origin: var(--perspectiveOrigin);
+            transform-origin: var(--perspectiveOrigin);
+            -webkit-transform: translateZ(var(--bgZTransform)) scale(var(--widthScale), var(--heightScale));
+            transform: translateZ(var(--bgZTransform)) scale(var(--widthScale), var(--heightScale));
+        }
+    }
+}
+
+
+
 

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -35,7 +35,10 @@ export function OnAfterRenderAsync()
 
 
     UpdateBGParallaxElement();
-    $(window).resize(UpdateBGParallaxElement()); // also update whenever zoom/resize of window occurs
+    $(window).resize(function () // also update whenever zoom/resize of window occurs
+    {
+        UpdateBGParallaxElement();
+    });
 }
 
 function UpdateBGParallaxElement()

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -23,15 +23,16 @@ export function OnAfterRenderAsync()
 
 
     UpdateBGParallaxElement();
+    UpdateBGParallaxWrapperScroll();
     $(window).resize(function () // also update whenever zoom/resize of window occurs
     {
         UpdateBGParallaxElement();
+        UpdateBGParallaxWrapperScroll();
     });
 
     ParallaxWrapperElement.onscroll = function ()
     {
-        BGParallaxWrapperElement.scrollTop = this.scrollTop;
-        console.log(BGParallaxWrapperElement.scrollTop);
+        UpdateBGParallaxWrapperScroll();
     }
 }
 
@@ -44,6 +45,10 @@ function UpdateBGParallaxElement()
 
     const cssBgZTransform = getCSSCustomPropertyValue("--bgZTransform", BGElement, "float");
     UpdateParallaxElement(BGElement, cssBgZTransform, false);
+}
+function UpdateBGParallaxWrapperScroll()
+{
+    BGParallaxWrapperElement.scrollTop = ParallaxWrapperElement.scrollTop;
 }
 
 function vhToPx(inVh)

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -1,5 +1,6 @@
 const BGElement = document.getElementById("BG"); /* BGElement element is currently hardcoded. Need to find a way to make this generic. Maybe a list of elements? */
 const ParallaxWrapperElement = document.getElementById("ParallaxWrapper");
+const BGParallaxWrapperElement = document.getElementById("BGParallaxWrapper");
 const PageContentElement = document.getElementById("PageContent");
 
 // Do the CSS's media and support queries for parallax pass?
@@ -25,6 +26,12 @@ export function OnAfterRenderAsync()
     {
         UpdateBGParallaxElement();
     });
+
+    ParallaxWrapperElement.onscroll = function ()
+    {
+        BGParallaxWrapperElement.scrollTop = this.scrollTop;
+        console.log(BGParallaxWrapperElement.scrollTop);
+    }
 }
 
 function UpdateBGParallaxElement()
@@ -67,7 +74,7 @@ function UpdateParallaxElement(inElement, inZTransform, inPreserveAspectRatio = 
     const cssPerspectiveValue = getCSSCustomPropertyValue("--perspectiveValue", ParallaxWrapperElement, "float");
     const heightScale = 1 + ((-inZTransform * heightRatio) / cssPerspectiveValue);
     const widthScale = 1 + ((-inZTransform * widthRatio) / cssPerspectiveValue);
-
+    console.log(`1 + ((${-inZTransform} * ${heightRatio}) / ${cssPerspectiveValue}) = ${heightScale}`);
 
     if (inPreserveAspectRatio)
     {
@@ -84,6 +91,8 @@ function UpdateParallaxElement(inElement, inZTransform, inPreserveAspectRatio = 
         return;
     }
 
+    document.getElementById("BGPageContent").style.setProperty("--PageWidth", `${PageContentElement.clientWidth}px`);
+    document.getElementById("BGPageContent").style.setProperty("--PageHeight", `${PageContentElement.clientHeight}px`);
     // Update the css variable
     inElement.style.setProperty("--widthScale", `${widthScale}`);
     inElement.style.setProperty("--heightScale", `${heightScale}`);

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -9,6 +9,7 @@ let bgZTransform = -300;
 export function SetBgZTransform(inBGZTransform)
 {
     bgZTransform = inBGZTransform;
+    BGElement.style.setProperty("--bgZTransform", `${bgZTransform}`);
 }
 /* END variables */
 

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -1,10 +1,11 @@
 const BGElement = document.getElementById("BG"); /* BGElement element is currently hardcoded. Need to find a way to make this generic. Maybe a list of elements? */
+const SharedVariablesWrapperElement = document.getElementById("SharedVariablesWrapper");
 const ParallaxWrapperElement = document.getElementById("ParallaxWrapper");
 const BGParallaxWrapperElement = document.getElementById("BGParallaxWrapper");
 const PageContentElement = document.getElementById("PageContent");
 
 // Do the CSS's media and support queries for parallax pass?
-function CSSParallaxStylesActive() { return getCSSCustomPropertyValue("--ParallaxSupported", ParallaxWrapperElement, "bool"); }
+function CSSParallaxStylesActive() { return getCSSCustomPropertyValue("--ParallaxSupported", SharedVariablesWrapperElement, "bool"); }
 
 export function OnAfterRenderAsync()
 {
@@ -71,7 +72,7 @@ function UpdateParallaxElement(inElement, inZTransform, inPreserveAspectRatio = 
     /* 
      * The formula that calculates the scale to counter the depth. "heightRatio" and "widthRatio" are variables added into the formula by me since I have the transform and perspective origin at the bottom.
      */
-    const cssPerspectiveValue = getCSSCustomPropertyValue("--perspectiveValue", ParallaxWrapperElement, "float");
+    const cssPerspectiveValue = getCSSCustomPropertyValue("--PerspectiveValue", SharedVariablesWrapperElement, "float");
     const heightScale = 1 + ((-inZTransform * heightRatio) / cssPerspectiveValue);
     const widthScale = 1 + ((-inZTransform * widthRatio) / cssPerspectiveValue);
     console.log(`1 + ((${-inZTransform} * ${heightRatio}) / ${cssPerspectiveValue}) = ${heightScale}`);

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -48,7 +48,8 @@ function UpdateBGParallaxElement()
 }
 function UpdateBGParallaxWrapperScroll()
 {
-    BGParallaxWrapperElement.scrollTop = ParallaxWrapperElement.scrollTop;
+    const scrollNormalized = ParallaxWrapperElement.scrollTop / (ParallaxWrapperElement.scrollHeight - ParallaxWrapperElement.clientHeight);
+    BGParallaxWrapperElement.scrollTop = scrollNormalized * (BGParallaxWrapperElement.scrollHeight - BGParallaxWrapperElement.clientHeight);
 }
 
 function vhToPx(inVh)

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -8,7 +8,9 @@ let bgZTransform = -300;
 export function SetBgZTransform(inBGZTransform)
 {
     bgZTransform = inBGZTransform;
-    BGElement.style.setProperty("--bgZTransform", `${bgZTransform}`);
+    BGElement.style.setProperty("--bgZTransform", `${bgZTransform}px`);
+
+    UpdateParallaxBGElement();
 }
 /* END variables */
 

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -77,8 +77,7 @@ function UpdateParallaxBGElement()
 
 /*
  * Counter's an element's depth by scaling up to perfectly fit PageContentElement. Good for page backgrounds.
- * Only limitations you might encounter is when you need to preserve the
- * element's aspect ratio while also having another specific need.
+ * Only limitation you may encounter is if you need to preserve aspect ratio (see comment within the inPreserveAspectRatio conditional block)
  */
 function UpdateParallaxElement(inElement, inZTransform, inPreserveAspectRatio = true)
 {

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -3,14 +3,16 @@ const ParallaxWrapperElement = document.getElementById("ParallaxWrapper");
 const PageContentElement = document.getElementById("PageContent");
 
 /* BEGIN variables */
-const perspectiveValue = 300;
-let bgZTransform = -300;
 export function SetBgZTransform(inBGZTransform)
 {
-    bgZTransform = inBGZTransform;
-    BGElement.style.setProperty("--bgZTransform", `${bgZTransform}px`);
-
-    UpdateParallaxBGElement();
+    if (SupportsCustomCSSProperties())
+    {
+        BGElement.style.setProperty("--bgZTransform", `${inBGZTransform}px`);
+    }
+    IsParallaxSupported()
+    {
+        UpdateParallaxBGElement();
+    }
 }
 /* END variables */
 
@@ -47,12 +49,6 @@ export function OnAfterRenderAsync()
     bodyEl.style.overflow = "hidden";
 
 
-    /*
-     * Set CSS custom properties' defaults.
-     * We do this regardless of support for parallax because it allows for getting the effect later on if the screen size changes or something like that.
-     */
-    ParallaxWrapperElement.style.setProperty("--perspectiveValue", `${perspectiveValue}px`);
-    BGElement.style.setProperty("--bgZTransform", `${bgZTransform}px`);
 
     IsParallaxSupported()
     {
@@ -72,7 +68,8 @@ export function OnAfterRenderAsync()
 
 function UpdateParallaxBGElement()
 {
-    UpdateParallaxElement(BGElement, bgZTransform, false);
+    const cssBgZTransform = getCSSCustomPropertyValue("--bgZTransform", BGElement, "float");
+    UpdateParallaxElement(BGElement, cssBgZTransform, false);
 }
 
 /*
@@ -87,8 +84,9 @@ function UpdateParallaxElement(inElement, inZTransform, inPreserveAspectRatio = 
     /* 
      * The formula that calculates the scale to counter the depth. "heightRatio" and "widthRatio" are variables added into the formula by me since I have the transform and perspective origin at the bottom.
      */
-    const heightScale = 1 + ((-inZTransform * heightRatio) / perspectiveValue);
-    const widthScale = 1 + ((-inZTransform * widthRatio) / perspectiveValue);
+    const cssPerspectiveValue = getCSSCustomPropertyValue("--perspectiveValue", ParallaxWrapperElement, "float");
+    const heightScale = 1 + ((-inZTransform * heightRatio) / cssPerspectiveValue);
+    const widthScale = 1 + ((-inZTransform * widthRatio) / cssPerspectiveValue);
 
 
     if (inPreserveAspectRatio)

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -5,20 +5,6 @@ const PageContentElement = document.getElementById("PageContent");
 // Do the CSS's media and support queries for parallax pass?
 function CSSParallaxStylesActive() { return getCSSCustomPropertyValue("--ParallaxSupported", ParallaxWrapperElement, "bool"); }
 
-/* BEGIN CSS setters */
-export function SetBgZTransform(inBGZTransform)
-{
-    if (SupportsCustomCSSProperties())
-    {
-        BGElement.style.setProperty("--bgZTransform", `${inBGZTransform}px`); // we do this regardless of support for parallax since the screen size could technically change later on (zoom/resizing). If support begins later on we will have this value ready
-        CSSParallaxStylesActive()
-        {
-            UpdateBGParallaxElement();
-        }
-    }
-}
-/* END CSS setters */
-
 export function OnAfterRenderAsync()
 {
 // BEGIN CSS styling

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -2,13 +2,10 @@ const BGElement = document.getElementById("BG"); /* BGElement element is current
 const ParallaxWrapperElement = document.getElementById("ParallaxWrapper");
 const PageContentElement = document.getElementById("PageContent");
 
-function CSSParallaxStylesActive()
-{
-    // Find out based on what the CSS media and support queries decided on
-    return getCSSCustomPropertyValue("--ParallaxSupported", ParallaxWrapperElement, "bool");
-}
+// Do the CSS's media and support queries for parallax pass?
+function CSSParallaxStylesActive() { return getCSSCustomPropertyValue("--ParallaxSupported", ParallaxWrapperElement, "bool"); }
 
-/* BEGIN variables */
+/* BEGIN CSS setters */
 export function SetBgZTransform(inBGZTransform)
 {
     if (SupportsCustomCSSProperties())
@@ -20,36 +17,30 @@ export function SetBgZTransform(inBGZTransform)
         }
     }
 }
-/* END variables */
+/* END CSS setters */
 
 export function OnAfterRenderAsync()
 {
+// BEGIN CSS styling
     /*
     * HTML and Body elements can cause an extra scrollbar, interfiering with our parallax setup.
     * I have noticed that the HTML vertical scrolling is also used for the mobile browser's url/search bar to go away and come back. If you don't allow vertical scrolling, then the bar is always there.
     */
     const htmlEl = document.documentElement;
     htmlEl.style.overflowX = "hidden";
-
     const bodyEl = document.body;
     bodyEl.style.margin = "0";
     bodyEl.style.overflow = "hidden";
-
+// END CSS styling
 
 
     UpdateBGParallaxElement();
-    // JQuery event detecting zoom/resizing of the window, keeping our BG element's parallax effect consistent accross any zoom/resize
-    $(window).resize(function ()
-    {
-        UpdateBGParallaxElement();
-    });
-
+    $(window).resize(UpdateBGParallaxElement()); // also update whenever zoom/resize of window occurs
 }
-
 
 function UpdateBGParallaxElement()
 {
-    if (!SupportsCustomCSSProperties() || !CSSParallaxStylesActive())   // TODO: Repetitive check (also done in calling funtion). Cleanup 
+    if (!SupportsCustomCSSProperties() || !CSSParallaxStylesActive())   // TODO: Repetitive check (already does in UpdateParallaxElement()). Cleanup
     {
         return;
     }

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -48,6 +48,7 @@ function UpdateBGParallaxElement()
 }
 function UpdateBGParallaxWrapperScroll()
 {
+    // Scroll BGParallaxWrapper relative to ParallaxWrapper using its normalized scroll value. This could probably even replace 3d rendered parallax since it's relative so it should work with any size, but lets not worry about that rn since this is working well.
     const scrollNormalized = ParallaxWrapperElement.scrollTop / (ParallaxWrapperElement.scrollHeight - ParallaxWrapperElement.clientHeight);
     BGParallaxWrapperElement.scrollTop = scrollNormalized * (BGParallaxWrapperElement.scrollHeight - BGParallaxWrapperElement.clientHeight);
 }

--- a/Website/Website/Shared/Components/ParallaxWrapper.razor.js
+++ b/Website/Website/Shared/Components/ParallaxWrapper.razor.js
@@ -65,6 +65,7 @@ export function OnAfterRenderAsync()
 function StartupCSSParallax()
 {
     ParallaxWrapperElement.style.setProperty("--perspectiveValue", `${perspectiveValue}px`);
+    BGElement.style.setProperty("--bgZTransform", `${bgZTransform}px`);
 
     UpdateParallaxBGElement();
 }
@@ -72,7 +73,6 @@ function StartupCSSParallax()
 
 function UpdateParallaxBGElement()
 {
-    BGElement.style.setProperty("--bgZTransform", `${bgZTransform}px`);
     UpdateParallaxElement(BGElement, bgZTransform, false);
 }
 

--- a/Website/Website/wwwroot/js/MyJavascriptFunctions.js
+++ b/Website/Website/wwwroot/js/MyJavascriptFunctions.js
@@ -38,3 +38,44 @@ function Lerp(start_value, end_value, pct)
 {
     return (start_value + (end_value - start_value) * pct);
 }
+
+function SupportsCustomCSSProperties()
+{
+    return CSS.supports("color", "var(--FakeCustomPropertyValue)");
+}
+
+/**
+ * Pass in an element and its CSS Custom Property that you want the value of.
+ * Optionally, you can determine what datatype you get back.
+ *
+ * @param {String} customPropertyName
+ * @param {HTMLELement} element=document.documentElement
+ * @param {String} castAs='string'
+ * @returns {*}
+ */
+function getCSSCustomPropertyValue(customPropertyName, element, castAs = 'string')
+{
+    let response = getComputedStyle(element).getPropertyValue(customPropertyName);
+
+    // Tidy up the string if there's something to work with
+    if (response.length)
+    {
+        response = response.replace(/\'|"/g, '').trim();
+    }
+
+    // Convert the response into a whatever type we wanted
+    switch (castAs)
+    {
+        case 'number':
+        case 'int':
+            return parseInt(response, 10);
+        case 'float':
+            return parseFloat(response, 10);
+        case 'boolean':
+        case 'bool':
+            return response === 'true' || response === '1';
+    }
+
+    // Return the string response by default
+    return response;
+};


### PR DESCRIPTION
Finish parallax setup
- Set up 2 separate parallax divs overlapping each other and scroll at the same time.
     - Reason for this is that we needed perspective origin at bottom of the page and in the center (the default one). You can't nest 2 of them so I created 2 separate parallax wrappers side by side to get the functionality.